### PR TITLE
Api spec updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# IODA
+# Console (IODA)
 
-This is the home of IODA.
+This is the home of Console (IODA).
 
 ## Exploration
-IODA is currently in its exploration phase. Some of the efforts contained in the repository are:
+Console (IODA) is currently in its exploration phase. Some of the efforts contained in the repository are:
 
 ## OpenAPI Documentation
 
@@ -15,7 +15,7 @@ The specification is kept in `./openapi/index.yaml`, and follows OpenAPI 3.1, al
 
 - Run `npm run docs` in a Git clone to see the absolute latest documentation of the checked out version.
 
-## The IODA Web Application
+## The Console (IODA) Web Application
 This is currently a bare bones symfony project
 
 ## Development
@@ -28,7 +28,7 @@ This is currently a bare bones symfony project
 - Clone this repository
 - Open a Bash terminal (such as Git Bash or WSL if on Windows)
 - Run `./bin/dev-start` to start the development environment
-- Run `./bin/dev-build` to (re)build the IODA application
+- Run `./bin/dev-build` to (re)build the Console (IODA) application
 
 #### Testing
 - Run `./bin/dev-test`

--- a/openapi/index.html
+++ b/openapi/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>IODA API Documentation</title>
+    <title>Console (IODA) API Documentation</title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.0.0-alpha.4/swagger-ui.css" />

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -1,6 +1,6 @@
 openapi: '3.1.0'
 info:
-  title: IODA
+  title: Console (IODA)
   version: '0.0.0'
   x-logo:
     url: https://www.nihr.ac.uk/layout/4.0/assets/logos/nihr-master-logo-325px.png

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -665,7 +665,7 @@ components:
       type: string
       format: uri
       examples:
-        - /resource/123
+        - /resources/123
     rel:
       type: string
       minLength: 1
@@ -1015,7 +1015,7 @@ components:
       type: string
       format: uri
       examples:
-        - /programme/123
+        - /programmes/123
     awardId:
       title: Award ID
       description: An award ID.
@@ -1031,7 +1031,7 @@ components:
       type: string
       format: uri
       examples:
-        - /award/06/303/20
+        - /awards/06/303/20
     callId:
       description: A research call ID.
       type: string
@@ -1043,7 +1043,7 @@ components:
       type: string
       format: uri
       examples:
-        - /call/06/303
+        - /calls/06/303
     journalId:
       title: Journal ID
       description: A journal ID.
@@ -1060,9 +1060,9 @@ components:
       type: string
       format: uri
       examples:
-        - /journal/eme
-        - /journal/hsdr
-        - /journal/pgfar
+        - /journals/eme
+        - /journals/hsdr
+        - /journals/pgfar
     volumeId:
       title: Volume ID
       description: A volume ID.
@@ -1075,7 +1075,7 @@ components:
       type: string
       format: uri
       examples:
-        - /volume/???
+        - /volumes/10
     publicationId:
       title: Publication ID
       description: A publication ID.
@@ -1090,7 +1090,7 @@ components:
       type: string
       format: uri
       examples:
-        - /publication/DANE8826
+        - /publications/DANE8826
     personId:
       title: Person ID
       description: A person ID.
@@ -1103,7 +1103,7 @@ components:
       type: string
       format: uri
       examples:
-        - /person/123
+        - /persons/123
     personInvolvement:
       name: Involvement
       oneOf:
@@ -1182,7 +1182,7 @@ components:
       type: string
       format: uri
       examples:
-        - /organisation/123
+        - /organisations/123
     userId:
       title: User ID
       '$ref': '#/components/schemas/uuidV4'
@@ -1192,7 +1192,7 @@ components:
       type: string
       format: uri
       examples:
-        - /user/123e4567-e89b-12d3-a456-426614174000
+        - /users/123e4567-e89b-12d3-a456-426614174000
     uuidV4:
       title: UUID v4
       description: A UUID version 4.


### PR DESCRIPTION
pluralised the examples, in line with the url eg '/awards/{awardId}' and examples: - /awards/06/303/20